### PR TITLE
Install rosetta for Apple M1 MacBooks

### DIFF
--- a/mac
+++ b/mac
@@ -70,6 +70,18 @@ update_shell() {
   sudo chsh -s "$shell_path" "$USER"
 }
 
+install_rosetta_if_required() {
+  # Check if running a new Apple silicon/arm64 chip, which requires rosetta for Intel software 
+  local OS ARCH
+  OS="$(uname)"
+  ARCH="$(uname -m)"
+  if [ "${OS}" = "Darwin" ] && [ "${ARCH}" = "arm64" ];
+  then
+    fancy_echo "Installing rosetta..."
+    echo "A" | softwareupdate --install-rosetta
+  fi
+}
+
 gem_install_or_update() {
   if gem list "$1" --installed > /dev/null; then
     gem update "$@"
@@ -144,6 +156,8 @@ case "$SHELL" in
     update_shell
     ;;
 esac
+
+install_rosetta_if_required
 
 if ! command -v brew >/dev/null; then
   install_homebrew


### PR DESCRIPTION
- Check for the new M1 architecture (Darwin == Apple, arm64 == Apple M1 silicon chip)
- Install rosetta without user prompt, otherwise it gets stuck if following the standard procedure of redirecting the output to a log file