### PR TITLE
[SC-58519] Update node to 18

### DIFF
--- a/mac
+++ b/mac
@@ -216,7 +216,7 @@ if [ ! $SKIP_HOMEBREW_UPDATE ]; then
 
     # Programming languages and package managers
     brew "libyaml" # should come after openssl
-    brew "node@14"
+    brew "node@18"
     brew "rbenv"
     brew "ruby-build"
     brew "yarn"
@@ -267,10 +267,10 @@ if brew_package_exists "postgresql@13"; then
   brew link --force postgresql@13
 fi
 
-if brew_package_exists "node@14"; then
+if brew_package_exists "node@18"; then
   fancy_echo "Configuring Node..."
-  brew unlink node@14
-  brew link --overwrite node@14
+  brew unlink node@18
+  brew link --overwrite node@18
 fi
 
 ruby_version="${RUBY_VERSION:-2.7.4}"


### PR DESCRIPTION
[SC-58519](https://app.shortcut.com/agendrix/story/58519/nodejs-14-eol)

> Présentement on utilise Node 14 partout, mais cette version arrive a end of life dans un mois.

> Le plus logique ça serait de migrer a v18 qui est LTS jusqu'à 2025.

