### PR TITLE
[KR - Q3-2024] Uniformiser les fichiers de config zshrc 

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,0 +1,20 @@
+# Path to your oh-my-zsh installation.
+export ZSH="$HOME/.oh-my-zsh"
+ZSH_THEME="robbyrussell"
+
+plugins=(git)
+
+source $ZSH/oh-my-zsh.sh
+
+export PATH="$HOME/.bin:$PATH"
+
+# Set PATH, MANPATH, etc., for Homebrew.
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
+export PATH="/usr/local/bin:$PATH"
+eval "$(rbenv init - --no-rehash)"
+
+# Rust
+[[ -f $HOME/.cargo/env ]] source "$HOME/.cargo/env"
+
+[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local

--- a/.zshrc
+++ b/.zshrc
@@ -15,6 +15,6 @@ export PATH="/usr/local/bin:$PATH"
 eval "$(rbenv init - --no-rehash)"
 
 # Rust
-[[ -f $HOME/.cargo/env ]] source "$HOME/.cargo/env"
+[[ -f $HOME/.cargo/env ]] && source "$HOME/.cargo/env"
 
-[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
+[[ -f $HOME/.zshrc.local ]] && source ~/.zshrc.local

--- a/.zshrc.local
+++ b/.zshrc.local
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+#############
+## Helpers ##
+#############
+
+# Helper shortcut to access git projects.
+# Use `p <project_folder>`, ex.: `p web`
+p()  { cd "$HOME/Projects/$1" || return; }
+_p() { _files -W ~/Projects -/; }
+compdef _p p
+
+#############
+## Exports ##
+#############
+
+# Misc env variables
+export EDITOR='code --wait'
+export PATH="$PATH:/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
+export RUBYOPT='--enable-yjit -W:deprecated -W:performance'
+
+# Puppeteer M1 https://github.com/puppeteer/puppeteer/issues/6622#issuecomment-928311570
+CHROMIUM_PATH=$(which chromium)
+echo "$CHROMIUM_PATH" | grep -q "not found" && echo "chromium not found, run \"brew install chromium --no-quarantine\" (needed for Puppeteer)"
+export PUPPETEER_EXECUTABLE_PATH="$CHROMIUM_PATH"
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
+# Ruby & MacOS bug https://github.com/rails/rails/issues/38560
+export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+
+export NODE_OPTIONS="--max-old-space-size=6144"
+
+# Node installation setup
+# (you can manage node with Homebrew OR NVM)
+#
+# # Homebrew setup:
+export PATH="/usr/local/opt/node@18/bin:$PATH"
+export LDFLAGS="-L/usr/local/opt/node@18/lib" 
+export CPPFLAGS="-I/usr/local/opt/node@18/include"
+#
+# # NVM setup:
+# export NVM_DIR="$HOME/.nvm"
+# [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+# [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+#############
+## Aliases ##
+#############
+
+alias be="bundle exec"
+alias dbreset="be rails db:drop db:create db:schema:load db:migrate db:seed"
+alias reset-azeroth="be rails azeroth:reset"
+alias sync-graphql="be rails graphql:dump_schema && yarn graphql-types"
+
+alias rails-console="be rails c"
+alias tail-logs="tail -f log/development.log"
+
+# Rails/Sorbet typing
+alias sync-i18n-types="yarn i18n-types"
+alias sync-rbis-dsl="be rails tapioca:dsl"
+alias sync-rbis-test="be rails rbi:test_dsl"

--- a/mac
+++ b/mac
@@ -45,15 +45,6 @@ fancy_echo() {
   printf "\n$fmt\n" "$@"
 }
 
-zshrc_path() {
-  if [ -w "$HOME/.zshrc.local" ]; then
-    zshrc="$HOME/.zshrc.local"
-  else
-    zshrc="$HOME/.zshrc"
-  fi
-  echo "$zshrc"
-}
-
 update_shell() {
   # shellcheck disable=SC3043
   local shell_path;

--- a/mac
+++ b/mac
@@ -272,10 +272,24 @@ if ! rbenv versions | grep --silent "$ruby_version"; then
 fi
 
 if [ ! "$SKIP_ZSHRC_SETUP" ]; then
+  # shellcheck disable=SC3043
+  local files_backed_up=false
+
   fancy_echo "Configuring .zshrc and .zshrc.local ..."
+
+  if [ -f "$HOME/.zshrc" ] || [ -f "$HOME/.zshrc.local" ]; then
+    fancy_echo "Backing up your current .zshrc and .zshrc.local ..."
+    [ -f "$HOME/.zshrc" ] && mv "$HOME/.zshrc" "$HOME/.zshrc.old"
+    [ -f "$HOME/.zshrc.local" ] && mv "$HOME/.zshrc.local" "$HOME/.zshrc.local.old"
+    files_backed_up=true
+  fi
 
   curl -o "$HOME/.zshrc" https://raw.githubusercontent.com/agendrix/laptop/master/.zshrc
   curl -o "$HOME/.zshrc.local" https://raw.githubusercontent.com/agendrix/laptop/master/.zshrc.local
+
+  if [ "$files_backed_up" = true ]; then
+    fancy_echo "Your old files have been backed up to ${HOME}/.zshrc.old and ${HOME}/.zshrc.local.old. Review them and add any needed changes to the new standardized files."
+  fi
 fi
 
 if [ -f "$HOME/.laptop.local" ]; then

--- a/mac
+++ b/mac
@@ -9,6 +9,7 @@ show_help() {
   echo "options:"
   echo "--help                              Show brief help."
   echo "--skip-homebrew-update              Skip Homebrew formulaes and casks update."
+  echo "--skip-zshrc-setup                    Skip configuring .zshrc and .zshrc.local."
   echo "--ruby-version                      Configure a specific ruby version."
   exit 0;
 }
@@ -19,6 +20,9 @@ while test $# -gt 0; do
         show_help;;
     (--skip-homebrew-update)
         SKIP_HOMEBREW_UPDATE="true"
+        shift;;
+    (--skip-zshrc-setup)
+        SKIP_ZSHRC_SETUP="true"
         shift;;
     (--ruby-version)
         RUBY_VERSION="$2"
@@ -34,8 +38,10 @@ done
 #
 
 fancy_echo() {
+  # shellcheck disable=SC3043
   local fmt="$1"; shift
 
+  # shellcheck disable=SC2059
   printf "\n$fmt\n" "$@"
 }
 
@@ -45,27 +51,14 @@ zshrc_path() {
   else
     zshrc="$HOME/.zshrc"
   fi
-  echo $zshrc
-}
-
-safe_append_to_zshrc() {
-  local text="$1" zshrc
-  local skip_new_line="${2:-0}"
-  zshrc=$(zshrc_path)
-
-  if ! grep -Fqs "$text" "$zshrc"; then
-    if [ "$skip_new_line" -eq 1 ]; then
-      printf "%s\n" "$text" >> "$zshrc"
-    else
-      printf "\n%s\n" "$text" >> "$zshrc"
-    fi
-  fi
+  echo "$zshrc"
 }
 
 update_shell() {
+  # shellcheck disable=SC3043
   local shell_path;
   shell_path="$(which zsh)"
-  if [ $shell_path != $SHELL ]; then
+  if [ "$shell_path" != "$SHELL" ]; then
     fancy_echo "Changing your shell to zsh ..."
     if ! grep "$shell_path" /etc/shells > /dev/null 2>&1 ; then
       fancy_echo "Adding '$shell_path' to /etc/shells"
@@ -77,6 +70,7 @@ update_shell() {
 
 install_rosetta_if_required() {
   # Check if running a new Apple silicon/arm64 chip, which requires rosetta for Intel software
+  # shellcheck disable=SC3043
   local OS ARCH
   OS="$(uname)"
   ARCH="$(uname -m)"
@@ -114,23 +108,6 @@ install_homebrew() {
   fancy_echo "Installing Homebrew ..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-  HOMEBREW_PREFIX=""
-  if ! type "brew" > /dev/null; then
-    if [ -d "/opt/homebrew" ]; then
-      # Check for macOS ARM
-      HOMEBREW_PREFIX="/opt/homebrew"
-    elif [ -d "/usr/local/homebrew" ]; then
-      # Check for macOS Intel
-      HOMEBREW_PREFIX="/usr/local/Homebrew"
-    elif [ -d "/home/linuxbrew/.linuxbrew" ]; then
-      # Check for Linux
-      HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
-    fi
-  else
-    HOMEBREW_PREFIX=$(brew --prefix)
-  fi
-  safe_append_to_zshrc '# Set PATH, MANPATH, etc., for Homebrew.'
-  safe_append_to_zshrc 'eval "$(/opt/homebrew/bin/brew shellenv)"'
   eval "$(/opt/homebrew/bin/brew shellenv)"
 }
 
@@ -165,11 +142,10 @@ if [ ! -d "$HOME/.bin/" ]; then
   mkdir "$HOME/.bin"
 fi
 
-if [ ! -f "$HOME/.zshrc" ]; then
-  touch "$HOME/.zshrc"
+if [ ! -d "$HOME/.oh-my-zsh" ]; then
+  fancy_echo "Installing Oh My Zsh ..."
+  git clone https://github.com/robbyrussell/oh-my-zsh.git "$HOME/.oh-my-zsh"
 fi
-
-safe_append_to_zshrc 'export PATH="$HOME/.bin:$PATH"'
 
 update_shell
 
@@ -188,7 +164,7 @@ if brew list | grep -Fq brew-cask; then
   brew uninstall --force brew-cask
 fi
 
-if [ ! $SKIP_HOMEBREW_UPDATE ]; then
+if [ ! "$SKIP_HOMEBREW_UPDATE" ]; then
   fancy_echo "Updating Homebrew formulae ..."
   brew update --quiet --force # https://github.com/Homebrew/brew/issues/1151
 
@@ -272,9 +248,8 @@ if brew_package_exists "node@18"; then
 fi
 
 ruby_version="${RUBY_VERSION:-3.3.0}"
-if ! rbenv versions | grep --silent $ruby_version; then
+if ! rbenv versions | grep --silent "$ruby_version"; then
   fancy_echo "Configuring Ruby..."
-  safe_append_to_zshrc 'eval "$(rbenv init - --no-rehash)"' 1
   eval "$(rbenv init -)"
 
   if ! rbenv versions | grep -Fq "$ruby_version"; then
@@ -305,8 +280,16 @@ if ! rbenv versions | grep --silent $ruby_version; then
   activate_exit_on_error
 fi
 
+if [ ! "$SKIP_ZSHRC_SETUP" ]; then
+  fancy_echo "Configuring .zshrc and .zshrc.local ..."
+
+  curl -o "$HOME/.zshrc" https://raw.githubusercontent.com/agendrix/laptop/master/.zshrc
+  curl -o "$HOME/.zshrc.local" https://raw.githubusercontent.com/agendrix/laptop/master/.zshrc.local
+fi
+
 if [ -f "$HOME/.laptop.local" ]; then
   fancy_echo "Running your customizations from ~/.laptop.local ..."
+  # shellcheck disable=SC1091
   . "$HOME/.laptop.local"
 fi
 


### PR DESCRIPTION
Dans l'optique d'un des KR Q3-2024 de l'équipe DEV, un sondage a été envoyé aux développeurs pour obtenir les fichiers de config zshrc. Au fil des années, les fichiers évoluent et peuvent grandement varier avec la base faite par `mac` et le repo `dotfiles`.

Avec les fichiers obtenus de 14 développeurs, les trucs communs et pertinents ont été regroupés. Pour simplifier le setup d'un nouvel poste de travail, le script `mac` a été modifé pour installer `oh-my-zsh` et copier les nouveaux fichiers standardisés. Ça veut également dire que le repo `dotfiles` ne sera plus nécessaire!

Les variables pour AWS, Kiosk et autres procédures déjà documentées ne sont pas dans les fichiers de base.

J'en ai profité pour disable certains warnings et enlever des lignes de code qui n'était plus nécessaires.

Une fois la PR merged, je vais communiquer avec les devs pour les tenir au courant des nouveaux fichiers, si certains d'entre eux veulent faire un petit cleanup.