### PR TITLE
Fix outdated OpenSSL version

### DIFF
--- a/mac
+++ b/mac
@@ -169,7 +169,7 @@ if [ ! "$SKIP_HOMEBREW_UPDATE" ]; then
 
     # Unix
     brew "git"
-    brew "openssl@1.1"
+    brew "openssl@3.4.0"
     brew "the_silver_searcher"
     brew "vim"
     brew "jq"

--- a/mac
+++ b/mac
@@ -244,7 +244,7 @@ if ! rbenv versions | grep --silent "$ruby_version"; then
   eval "$(rbenv init -)"
 
   if ! rbenv versions | grep -Fq "$ruby_version"; then
-    OPEN_SSL_PREFIX=$(brew --prefix openssl@1.1)
+    OPEN_SSL_PREFIX=$(brew --prefix openssl@3.4.0)
 
     PATH="$OPEN_SSL_PREFIX/bin:$PATH" \
     LDFLAGS="-L$OPEN_SSL_PREFIX/lib" \

--- a/mac
+++ b/mac
@@ -169,7 +169,7 @@ if [ ! "$SKIP_HOMEBREW_UPDATE" ]; then
 
     # Unix
     brew "git"
-    brew "openssl@3.4.0"
+    brew "openssl@3.4"
     brew "the_silver_searcher"
     brew "vim"
     brew "jq"
@@ -244,7 +244,7 @@ if ! rbenv versions | grep --silent "$ruby_version"; then
   eval "$(rbenv init -)"
 
   if ! rbenv versions | grep -Fq "$ruby_version"; then
-    OPEN_SSL_PREFIX=$(brew --prefix openssl@3.4.0)
+    OPEN_SSL_PREFIX=$(brew --prefix openssl@3.4)
 
     PATH="$OPEN_SSL_PREFIX/bin:$PATH" \
     LDFLAGS="-L$OPEN_SSL_PREFIX/lib" \


### PR DESCRIPTION
Petit fix simple, la version d'OpenSSL spécifiée (1.1) n'était plus disponible online.

On update donc à 3.4.0, qui est la version qui s'installe actuellement quand on fait une installation manuelle de Homebrew.