### PR TITLE
Add Ripgrep

### DIFF
--- a/mac
+++ b/mac
@@ -171,6 +171,7 @@ if [ ! "$SKIP_HOMEBREW_UPDATE" ]; then
     brew "git"
     brew "openssl@3.4"
     brew "the_silver_searcher"
+    brew "rg"
     brew "vim"
     brew "jq"
     brew "bind"


### PR DESCRIPTION
Sur la documentation de [Claude](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview), ils suggèrent d’installer ripgrep pour améliorer la recherche de fichiers. Notre script propose ag, mais celui-ci est devenu de moins en moins populaire. Comme j’ignore si des scripts l’utilisent, je l’ai laissé.