### PR TITLE
fix: align node PATH with node@22, bump default Ruby to match web app, and add shared-mime-info

### DIFF
--- a/.zshrc.local
+++ b/.zshrc.local
@@ -34,9 +34,9 @@ export NODE_OPTIONS="--max-old-space-size=6144"
 # (you can manage node with Homebrew OR NVM)
 #
 # # Homebrew setup:
-export PATH="/usr/local/opt/node@18/bin:$PATH"
-export LDFLAGS="-L/usr/local/opt/node@18/lib" 
-export CPPFLAGS="-I/usr/local/opt/node@18/include"
+export PATH="/usr/local/opt/node@22/bin:$PATH"
+export LDFLAGS="-L/usr/local/opt/node@22/lib" 
+export CPPFLAGS="-I/usr/local/opt/node@22/include"
 #
 # # NVM setup:
 # export NVM_DIR="$HOME/.nvm"

--- a/mac
+++ b/mac
@@ -229,6 +229,9 @@ if [ ! "$SKIP_HOMEBREW_UPDATE" ]; then
     # Websockets
     brew "anycable-go"
 
+    # MIME database (needed by mimemagic)
+    brew "shared-mime-info"
+
     cask "handy"
 EOF
   activate_exit_on_error
@@ -252,7 +255,7 @@ if brew_package_exists "node@22"; then
   brew link --overwrite node@22
 fi
 
-ruby_version="${RUBY_VERSION:-3.3.0}"
+ruby_version="${RUBY_VERSION:-3.4.7}"
 if ! rbenv versions | grep --silent "$ruby_version"; then
   fancy_echo "Configuring Ruby..."
   eval "$(rbenv init -)"


### PR DESCRIPTION
Second set of small fixes to make the web app run locally:

* align node PATH with node@22: The brew file points to v22 but the .zshrc.local file still pointed to v18. Causing error:
```
checking whether LDFLAGS is valid... no
configure: error: something wrong with LDFLAGS="-L/usr/local/opt/node@18/lib"
external command failed with status 1
```

* bump default Ruby to match web app: just aligning the setup with the actual web app repo version.

* add shared-mime-info: needed dependency when installing the mimemagic gem. Error logs for ref:
```
An error occurred while installing mimemagic (0.4.3), and Bundler cannot continue.

In Gemfile:
  axlsx_styler was resolved to 0.2.0, which depends on
    axlsx was resolved to 3.0.0.pre, which depends on
      mimemagic
Bundler::InstallError: Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/patrickmalouin/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/mimemagic-0.4.3/ext/mimemagic
/Users/patrickmalouin/.rbenv/versions/3.4.7/bin/ruby -rrubygems /Users/patrickmalouin/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/rake-13.4.2/exe/rake RUBYARCHDIR\=/Users/patrickmalouin/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/extensions/arm64-darwin-25/3.4.0/mimemagic-0.4.3 RUBYLIBDIR\=/Users/patrickmalouin/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/extensions/arm64-darwin-25/3.4.0/mimemagic-0.4.3
rake aborted!
Could not find MIME type database in the following locations: ["/usr/local/share/mime/packages/freedesktop.org.xml", "/opt/homebrew/share/mime/packages/freedesktop.org.xml", "/opt/local/share/mime/packages/freedesktop.org.xml", "/usr/share/mime/packages/freedesktop.org.xml"]

Ensure you have either installed the shared-mime-info package for your distribution, or
obtain a version of freedesktop.org.xml and set FREEDESKTOP_MIME_TYPES_PATH to the location
of that file.
```